### PR TITLE
Fixed RGB32

### DIFF
--- a/KNLMeansCL/NLMAvisynth.cpp
+++ b/KNLMeansCL/NLMAvisynth.cpp
@@ -216,10 +216,11 @@ NLMAvisynth::NLMAvisynth(PClip _child, const int _d, const int _a, const int _s,
     cl_channel_type channel_type_p_out = NULL;
     if (vi.IsPlanar() || vi.IsRGB32() || vi.IsRGB64()) {
         if (vi.BitsPerComponent() == 8) {
+                channel_order = CL_RGBA;
             if (stacked) {
                 pre_processing = true;
                 clip_t |= NLM_CLIP_TYPE_STACKED;
-                channel_type_u = CL_UNORM_INT16;
+                channel_type_u = CL_UNORM_INT8;
                 channel_type_p = CL_UNSIGNED_INT8;
             }
             else {

--- a/KNLMeansCL/NLMAvisynth.cpp
+++ b/KNLMeansCL/NLMAvisynth.cpp
@@ -227,6 +227,7 @@ NLMAvisynth::NLMAvisynth(PClip _child, const int _d, const int _a, const int _s,
                 clip_t |= NLM_CLIP_TYPE_UNORM;
                 channel_type_u = channel_type_p = CL_UNORM_INT8;
             }
+            printf("FFmpeg is just displaying the alpha channel. Compare to RGBAdjust(ab=255).\n");
         }
         else if (vi.BitsPerComponent() == 10 && 
                  ( (!strcasecmp(channels, "YUV") && vi.Is444()) || vi.IsPlanarRGB() || vi.IsPlanarRGBA())


### PR DESCRIPTION
Although RGB32 doesn't work with ColorBars in ffmpeg avisynth 3.7.3+. That's probably how it should be.